### PR TITLE
Set a reasonable backlog value

### DIFF
--- a/src/kraken_tcp_server.erl
+++ b/src/kraken_tcp_server.erl
@@ -38,6 +38,7 @@
 -define(TCP_OPTIONS, [
     binary,
     {packet, line},
+    {backlog, 1024},
     {active, false},
     {reuseaddr, true}]).
 


### PR DESCRIPTION
The default backlog value for gen_tcp is 5, which is wholly unsuitable for a busy server.  Ran into this issue in another project.

If the backlog is set > /proc/sys/net/core/somaxconn then it will silently be set to whatever the value of somaxconn is.
