### PR TITLE
Pin sync to 0.1.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
     {log4erl, "0.9.0", {git, "git://github.com/krisr/log4erl.git", "0b3531f64200c2cfbb0535274b4c0042c994fbbe"}},
-    {sync, ".*", {git, "https://github.com/rustyio/sync.git", "HEAD"}}
+    {sync, "0.1.3", {git, "https://github.com/rustyio/sync.git", "HEAD"}}
    ]}.


### PR DESCRIPTION
Version 0.2.0 unfortunately does not work with rebar
https://github.com/rustyio/sync/issues/92